### PR TITLE
Upgrade Node version to 14.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,7 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 ## Node.js
 ##
 
-ENV NODE_VERSION 12.20.1
+ENV NODE_VERSION 14.15.4
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
## Changed
- Upgrade Node version from 12.16.3 to 14.15.4
  - Update GPG key for Node binaries from Node README
- Upgrade Yarn version from 1.22.4 to 1.22.10
