### PR TITLE
Upgrade Ruby 2.7.3 and Bundler 2.2.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN set -eux; \
   } >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.7
-ENV RUBY_VERSION 2.7.2
-ENV RUBY_DOWNLOAD_SHA256 1b95ab193cc8f5b5e59d2686cb3d5dcf1ddf2a86cb6950e0b4bdaae5040ec0d6
-ENV BUNDLER_VERSION 2.1.4
+ENV RUBY_VERSION 2.7.3
+ENV RUBY_DOWNLOAD_SHA256 5e91d1650857d43cd6852e05ac54683351e9c301811ee0bef43a67c4605e7db1
+ENV BUNDLER_VERSION 2.2.21
 
 # Persistent packages
 RUN set -eux; \
@@ -154,25 +154,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -ex \
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils --no-install-recommends \
+    && apt-get update && apt-get install -y ca-certificates curl wget git gnupg dirmngr xz-utils --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && for key in \
-      4ED778F539E3634C779C87C6D7062848A1AB005C \
-      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-      108F52B48DB57BB0CC439B2997B01419BD92F80A \
-      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
-    ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
+    && git clone https://github.com/nodejs/release-keys.git \
+    && release-keys/cli.sh import \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \


### PR DESCRIPTION
## Upgraded
- Upgrade Ruby from 2.7.2 to 2.7.3 ([Only Security Patches](https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/))
- Upgrade Bundler from 2.1.4 to 2.2.21 to ensure Rubygems multiple source resolving is correctly separating public and private libraries
- Keyservers for Node.js GPG keys is taken down, replaced with nodejs/release-keys until there's a more stable solutions